### PR TITLE
fix: put config file into userData directory

### DIFF
--- a/src/ConfigurationInterface.js
+++ b/src/ConfigurationInterface.js
@@ -1,11 +1,13 @@
 const fileSystem = require('fs')
+const path = require('path')
+const { app } = require('electron')
 
 class ConfigurationInterface {
     /**
      * PRIVATE FIELDS
      */
 
-    #filePath = './config.json'
+    #filePath = path.join(app.isPackaged ? app.getPath('userData') : '', 'config.json')
 
     #defaultConfiguration = {
         window: { opacity: 1, width: 900, height: 550 },


### PR DESCRIPTION
Fixes https://github.com/supernoter/noter/issues/35

This puts `config.json` into os specific `userData` folder in packaged app, but keep it relative when in development mode
https://www.electronjs.org/docs/latest/api/app#appispackaged-readonly
https://www.electronjs.org/docs/latest/api/app#appgetpathname

Maybe want to implement a function to open `config.json` directly from main menu later if this PR is merged, since its location would not be trivial to users.