### PR TITLE
feat: make config file location platform independent

### DIFF
--- a/src/ConfigurationInterface.js
+++ b/src/ConfigurationInterface.js
@@ -1,92 +1,128 @@
 const fileSystem = require('fs')
+const path = require('path')
 
-class ConfigurationInterface {
-    /**
-     * PRIVATE FIELDS
-     */
+/**
+ * Creates a ConfigurationInterface with the specified Electron app
+ * @param {Object} app - The Electron app object
+ * @returns {ConfigurationInterface} - An instance of ConfigurationInterface
+ */
+function createConfigurationInterface(app) {
+    class ConfigurationInterface {
+        /**
+         * PRIVATE FIELDS
+         */
+        #filePath = null
+        #defaultConfiguration = {
+            window: { opacity: 1, width: 900, height: 550 },
+            font: { colour: 'blue', size: '25px', family: 'Arial' },
+            background: {
+                colour: 'white',
+                gradient: null,
+                image: null,
+                opacity: '100%',
+            },
+            'status-bar': {
+                font: { colour: 'black', size: '15px', family: 'Arial' },
+                background: { colour: 'white' },
+            },
+            preview: {
+                font: { colour: 'black', size: '20px', family: 'Arial' },
+                background: { colour: 'blue' },
+            },
+        }
 
-    #filePath = './config.json'
-
-    #defaultConfiguration = {
-        window: { opacity: 1, width: 900, height: 550 },
-        font: { colour: 'blue', size: '25px', family: 'Arial' },
-        background: {
-            colour: 'white',
-            gradient: null,
-            image: null,
-            opacity: '100%',
-        },
-        'status-bar': {
-            font: { colour: 'black', size: '15px', family: 'Arial' },
-            background: { colour: 'white' },
-        },
-        preview: {
-            font: { colour: 'black', size: '20px', family: 'Arial' },
-            background: { colour: 'blue' },
-        },
-    }
-
-    /**
-     * PUBLIC METHODS
-     */
-
-    // retrieves the configuration data object
-    getConfigurationData() {
-        this.#ensureConfigurationFileExistence()
-        const configurationDataObject = this.#loadConfigurations()
-        return configurationDataObject
-    }
-
-    /**
-     * PRIVATE METHODS
-     */
-
-    // opens a configuration file and returns its data
-    #openConfigurationFile(filePath) {
-        // const fileSystem = require("fs");
-
-        const fileData = fileSystem.readFileSync(
-            filePath,
-            'binary',
-            (error, fileData) => {
-                if (error) {
-                    console.error('Error trying to read the file: ', error)
-                    return null
-                }
-
-                return fileData
+        constructor() {
+            // Set the configuration file path using app.getPath. This allows
+            // us to use platform specific path, e.g. on Linux the default
+            // location will be ~/.config/noter/config.json
+            // https://www.electronjs.org/docs/latest/api/app#appgetpathname
+            if (app) {
+                this.#filePath = path.join(
+                    app.getPath('userData'),
+                    'config.json'
+                )
+            } else {
+                // Fallback to local path if app is not provided
+                this.#filePath = './config.json'
             }
-        )
-
-        return fileData
-    }
-
-    // receives a JS object as a string and converts it to a JSON
-    #parseFileData(fileData) {
-        if (fileData == null || fileData.trim() === '') {
-            console.error('The file data is empty.')
-            return
         }
 
-        return JSON.parse(fileData)
-    }
+        /**
+         * PUBLIC METHODS
+         */
+        // retrieves the configuration data object
+        getConfigurationData() {
+            this.#ensureConfigurationFileExistence()
+            const configurationDataObject = this.#loadConfigurations()
+            return configurationDataObject
+        }
 
-    // opens the configuration file and returns its data as an object
-    #loadConfigurations() {
-        const fileData = this.#openConfigurationFile(this.#filePath)
-        return this.#parseFileData(fileData)
-    }
-
-    // verifies if the configuration file exists in the specified path
-    // if not, it'll be created there
-    #ensureConfigurationFileExistence() {
-        if (!fileSystem.existsSync(this.#filePath)) {
-            fileSystem.writeFileSync(
-                this.#filePath,
-                JSON.stringify(this.#defaultConfiguration, null, 2)
+        /**
+         * PRIVATE METHODS
+         */
+        // opens a configuration file and returns its data
+        #openConfigurationFile(filePath) {
+            const fileData = fileSystem.readFileSync(
+                filePath,
+                'binary',
+                (error, fileData) => {
+                    if (error) {
+                        console.error('error reading file: ', error)
+                        return null
+                    }
+                    return fileData
+                }
             )
+            return fileData
+        }
+
+        // receives a JS object as a string and converts it to a JSON
+        #parseFileData(fileData) {
+            if (fileData == null || fileData.trim() === '') {
+                console.error('empty config file')
+                return this.#defaultConfiguration
+            }
+            try {
+                return JSON.parse(fileData)
+            } catch (error) {
+                console.error('error parsing configuration file:', error)
+                return this.#defaultConfiguration
+            }
+        }
+
+        // opens the configuration file and returns its data as an object
+        #loadConfigurations() {
+            try {
+                const fileData = this.#openConfigurationFile(this.#filePath)
+                return this.#parseFileData(fileData)
+            } catch (error) {
+                console.error('error loading configurations:', error)
+                return this.#defaultConfiguration
+            }
+        }
+
+        // verifies if the configuration file exists in the specified path
+        // if not, it'll be created there
+        #ensureConfigurationFileExistence() {
+            if (!fileSystem.existsSync(this.#filePath)) {
+                try {
+                    // Ensure the directory exists
+                    const dirPath = path.dirname(this.#filePath)
+                    if (!fileSystem.existsSync(dirPath)) {
+                        fileSystem.mkdirSync(dirPath, { recursive: true })
+                    }
+                    // Write the default configuration
+                    fileSystem.writeFileSync(
+                        this.#filePath,
+                        JSON.stringify(this.#defaultConfiguration, null, 2)
+                    )
+                } catch (error) {
+                    console.error('error creating configuration file:', error)
+                }
+            }
         }
     }
+    return new ConfigurationInterface()
 }
 
-module.exports = new ConfigurationInterface()
+module.exports = createConfigurationInterface

--- a/src/CustomizationHandler.js
+++ b/src/CustomizationHandler.js
@@ -1,66 +1,102 @@
 const path = require('path')
 const { screen } = require('electron/main')
-const configurationInterface = require('./ConfigurationInterface')
+const createConfigurationInterface = require('./ConfigurationInterface')
 
-// todo: document methods
-
-class CustomizationHandler {
-    constructor() {
-        const { window, font, background, statusbar, preview } =
-            configurationInterface.getConfigurationData()
-
-        this.window = window
-        this.font = font
-        this.background = background
-        this.statusBar = statusbar
-        this.preview = preview
-    }
-
-    // apply customizations to the editor
-    applyCustomizationsToEditor() {
-        window.addEventListener('NoterEditorElementsLoaded', () => {
-            const content = document.querySelector('#note-textarea') // editor
-            console.log('content ' + content)
-            content.style.color = this.font['colour']
-            content.style.fontSize = this.font['size']
-            content.style.fontFamily = this.font['family']
-            content.style.backgroundColor = this.background['colour']
-            content.style.opacity = this.background['opacity']
-
-            const statusBar = document.querySelector('.status-bar') // status bar
-            statusBar.style.backgroundColor =
-                this.statusBar['background']['colour']
-            statusBar.style.color = this.statusBar['font']['colour']
-            statusBar.style.fontSize = this.statusBar['font']['size']
-            statusBar.style.fontFamily = this.statusBar['font']['family']
-
-            const preview = document.querySelector('#preview') // preview mode
-            preview.style.backgroundColor = this.preview['background']['colour']
-            preview.style.color = this.preview['font']['colour']
-            preview.style.fontSize = this.preview['font']['size']
-            preview.style.fontFamily = this.preview['font']['family']
-
-            console.log('applied customizations to editor')
-        })
-    }
-
-    // generates a window object with configurations set by the user
-    getWindowOptions() {
-        return {
-            width: this.window['width'],
-            height: this.window['height'],
-            transparent: this.window['opacity'] < 1,
-            opacity: this.window['opacity'],
-            webPreferences: {
-                // TODO: check if we need all these options
-                nodeIntegration: true,
-                preload: path.join(__dirname, 'preload.js'),
-                contextIsolation: true,
-                enableRemoteModule: false,
-                sandbox: false,
-            },
+/**
+ * Create a CustomizationHandler with the specified app object
+ * @param {Object} app - The Electron app object
+ * @returns {CustomizationHandler} - An instance of CustomizationHandler
+ */
+function createCustomizationHandler(app) {
+    // Create the configuration interface with the app object
+    const configurationInterface = createConfigurationInterface(app)
+    
+    class CustomizationHandler {
+        constructor() {
+            const {
+                window,
+                font,
+                background,
+                'status-bar': statusbar,
+                preview,
+            } = configurationInterface.getConfigurationData()
+            this.window = window
+            this.font = font
+            this.background = background
+            this.statusBar = statusbar
+            this.preview = preview
+        }
+        
+        // apply customizations to the editor
+        applyCustomizationsToEditor() {
+            window.addEventListener('NoterEditorElementsLoaded', () => {
+                const content = document.querySelector('#note-textarea') // editor
+                console.log('content ' + content)
+                
+                // Apply font styles
+                content.style.color = this.font['colour']
+                content.style.fontSize = this.font['size']
+                content.style.fontFamily = this.font['family']
+                
+                // Apply background
+                if (this.background['image']) {
+                    // If there's a background image, use it
+                    console.log('Setting background image:', this.background['image'])
+                    content.style.backgroundImage = `url('${this.background['image']}')`
+                    content.style.backgroundSize = 'cover'
+                    content.style.backgroundPosition = 'center'
+                    content.style.backgroundRepeat = 'no-repeat'
+                } else if (this.background['gradient']) {
+                    // If there's a gradient, use it
+                    content.style.backgroundImage = this.background['gradient']
+                    content.style.backgroundSize = 'cover'
+                } else {
+                    // Otherwise just use the background color
+                    content.style.backgroundImage = 'none'
+                    content.style.backgroundColor = this.background['colour']
+                }
+                
+                // Apply opacity
+                content.style.opacity = this.background['opacity']
+                
+                // Status bar styling
+                const statusBar = document.querySelector('.status-bar') // status bar
+                statusBar.style.backgroundColor = this.statusBar['background']['colour']
+                statusBar.style.color = this.statusBar['font']['colour']
+                statusBar.style.fontSize = this.statusBar['font']['size']
+                statusBar.style.fontFamily = this.statusBar['font']['family']
+                
+                // Preview styling
+                const preview = document.querySelector('#preview') // preview mode
+                preview.style.backgroundColor = this.preview['background']['colour']
+                preview.style.color = this.preview['font']['colour']
+                preview.style.fontSize = this.preview['font']['size']
+                preview.style.fontFamily = this.preview['font']['family']
+                
+                console.log('applied customizations to editor')
+            })
+        }
+        
+        // generates a window object with configurations set by the user
+        getWindowOptions() {
+            return {
+                width: this.window['width'],
+                height: this.window['height'],
+                transparent: this.window['opacity'] < 1,
+                opacity: this.window['opacity'],
+                webPreferences: {
+                    // TODO: check if we need all these options
+                    nodeIntegration: true,
+                    preload: path.join(__dirname, 'preload.js'),
+                    contextIsolation: true,
+                    enableRemoteModule: false,
+                    sandbox: false,
+                },
+            }
         }
     }
+    
+    return new CustomizationHandler()
 }
 
-module.exports = new CustomizationHandler()
+module.exports = createCustomizationHandler

--- a/src/WindowHandler.js
+++ b/src/WindowHandler.js
@@ -1,15 +1,24 @@
-const { BrowserWindow } = require('electron')
-const customizationHandler = require('./CustomizationHandler')
+const path = require('path')
+const { BrowserWindow, screen } = require('electron/main')
+const createCustomizationHandler = require('./CustomizationHandler')
 
-// wrapper class for creating a window with the proper configurations
-// set by the user
-class WindowHandler {
-    createWindow() {
-        const mainWindow = new BrowserWindow(
-            customizationHandler.getWindowOptions()
-        )
-        return mainWindow
+/**
+ * Create a WindowHandler with the specified app object
+ * @param {Object} app - The Electron app object
+ * @returns {WindowHandler} - An instance of WindowHandler
+ */
+function createWindowHandler(app) {
+    // Create customization handler
+    const customizationHandler = createCustomizationHandler(app)
+
+    class WindowHandler {
+        createWindow() {
+            const windowOptions = customizationHandler.getWindowOptions()
+            return new BrowserWindow(windowOptions)
+        }
     }
+
+    return new WindowHandler()
 }
 
-module.exports = new WindowHandler()
+module.exports = createWindowHandler

--- a/src/main.js
+++ b/src/main.js
@@ -1,63 +1,74 @@
 const { app, BrowserWindow, ipcMain } = require('electron/main')
-const windowHandler = require('./WindowHandler')
-const menu = require('./menu')
 const process = require('process')
 const fs = require('fs')
 const path = require('path')
+const menu = require('./menu')
+const createWindowHandler = require('./WindowHandler')
+const createConfigurationInterface = require('./ConfigurationInterface')
 
 // Parse command line arguments
 const argv = process.argv.slice(1) // Remove the first element (path to electron executable)
 const showIntro = !argv.includes('--no-intro')
 
+// Reference to main window
+let mainWindow
+// Reference to window handler
+let windowHandler
+// Reference to configuration interface
+let configInterface
+
 // Create path for all the user notes
 const notesDir = path.join(app.getPath('documents'), 'noter')
-
 const WELCOME_NOTE_TEXT = `# Welcome to NOTER!
-
 Noter is a simple, yet powerful markdown editor that we hope you will enjoy using.
-
 Find out more at [supernoter.xyz](https://supernoter.xyz) and on GitHub at
 [supernoter/noter](https://github.com/supernoter/noter).
 `
 
-let mainWindow // reference to main window
+// Set up IPC handlers
+function setupIpcHandlers() {
+    ipcMain.handle('get-notes', async () => {
+        if (!fs.existsSync(notesDir)) {
+            fs.mkdirSync(notesDir, { recursive: true })
+            // create a welcome note
+            const welcomeNote = path.join(notesDir, 'Welcome.md')
+            fs.writeFileSync(welcomeNote, WELCOME_NOTE_TEXT, 'utf-8')
+        }
+        const files = fs
+            .readdirSync(notesDir)
+            .map((filename) => ({
+                name: filename,
+                path: path.join(notesDir, filename),
+                mtime: fs.statSync(path.join(notesDir, filename)).mtime,
+            }))
+            .sort((a, b) => b.mtime - a.mtime)
+            .map((file) => file.name)
+        return files
+    })
 
-ipcMain.handle('get-notes', async () => {
-    if (!fs.existsSync(notesDir)) {
-        fs.mkdirSync(notesDir, { recursive: true })
-        // create a welcome note
-        const welcomeNote = path.join(notesDir, 'Welcome.md')
-        fs.writeFileSync(welcomeNote, WELCOME_NOTE_TEXT, 'utf-8')
-    }
-    const files = fs
-        .readdirSync(notesDir)
-        .map((filename) => ({
-            name: filename,
-            path: path.join(notesDir, filename),
-            mtime: fs.statSync(path.join(notesDir, filename)).mtime,
-        }))
-        .sort((a, b) => b.mtime - a.mtime)
-        .map((file) => file.name)
-    return files
-})
+    ipcMain.handle('read-note', async (event, filename) => {
+        const filePath = path.join(notesDir, filename)
+        if (fs.existsSync(filePath)) {
+            mainWindow.webContents.send('set-editor-filepath', filePath)
+            return fs.readFileSync(filePath, 'utf8') // Return note content
+        }
+        return ''
+    })
 
-ipcMain.handle('read-note', async (event, filename) => {
-    const filePath = path.join(notesDir, filename)
-    if (fs.existsSync(filePath)) {
-        mainWindow.webContents.send('set-editor-filepath', filePath)
-        return fs.readFileSync(filePath, 'utf8') // Return note content
-    }
-    return ''
-})
+    // Add a new IPC handler to check if intro should be shown
+    ipcMain.handle('should-show-intro', () => {
+        return showIntro
+    })
 
-// Add a new IPC handler to check if intro should be shown
-ipcMain.handle('should-show-intro', () => {
-    return showIntro
-})
+    // Add handler to get configuration
+    ipcMain.handle('get-config', () => {
+        return configInterface.getConfigurationData()
+    })
+}
 
 // createInitialWindow creates a window, set the menu and loads our application
 // HTML.
-createInitialWindow = () => {
+function createInitialWindow() {
     mainWindow = windowHandler.createWindow()
     menu.createMenu(mainWindow)
     mainWindow.loadFile('./index.html')
@@ -67,12 +78,20 @@ createInitialWindow = () => {
     }
 }
 
-// Many of Electron's core modules are Node.js event emitters that adhere to
-// Node's asynchronous event-driven architecture. The app module is one of
-// these emitters.
-
+// Initialize the application
 app.whenReady().then(() => {
+    // Initialize configuration interface with app object
+    configInterface = createConfigurationInterface(app)
+
+    // Initialize window handler with app object
+    windowHandler = createWindowHandler(app)
+
+    // Set up IPC handlers
+    setupIpcHandlers()
+
+    // Create the main window
     createInitialWindow()
+
     app.on('activate', () => {
         if (BrowserWindow.getAllWindows().length === 0) {
             createInitialWindow()
@@ -81,13 +100,7 @@ app.whenReady().then(() => {
 })
 
 app.on('window-all-closed', () => {
-    if (process.platform !== 'Darwin') {
+    if (process.platform !== 'darwin') {
         app.quit()
     }
 })
-
-// You might have noticed the capitalization difference between the app and
-// BrowserWindow modules. Electron follows typical JavaScript conventions here,
-// where PascalCase modules are instantiable class constructors (e.g.
-// BrowserWindow, Tray, Notification) whereas camelCase modules are not
-// instantiable (e.g. app, ipcRenderer, webContents).


### PR DESCRIPTION

This change allows us to use the "app" object in the configuration/customization module and to use platform specific path as documented here:

https://www.electronjs.org/docs/latest/api/app#appgetpathname

This required a couple of changes in main, preload as well, mostly to accomodate the "app" object passed into the various classes.

The problem was that modules required by the initial module for electron do not have the "app" object created properly just yet. We have to move the initialization to a later stage.

![screenshot-2025-02-27-114618](https://github.com/user-attachments/assets/0dc6a5d6-c760-4d7e-a462-2bff79c0d287)